### PR TITLE
Spring Boot 2.5への対応。DBを常に初期化するように変更する

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,6 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.sql-script-encoding=UTF-8
 spring.datasource.initialization-mode=always
+spring.sql.init.mode=always
 spring.messages.basename=messages
 spring.jpa.hibernate.ddl-auto=none
 


### PR DESCRIPTION
## 概要

Spring Bootのバージョンアップを行ったが、データベースの初期化に失敗してしまう。  
Spring Boot 2.5.のリリースノートを確認したところ、 DBの初期化に関する設定が必要とのこと。
  
https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes

> SQL Script DataSource Initialization
The underlying method used to support schema.sql and data.sql scripts has been redesigned in Spring Boot 2.5. spring.datasource.* properties related to DataSource initialization have been deprecated in favor of new spring.sql.init.* properties. These properties can also be used to initialize an SQL database accessed via R2DBC.

> schema.sql and data.sql Files
With Spring Boot 2.5.1 and above, the new SQL initialization properties support detection of embedded datasources for JDBC and R2DBC. By default, SQL database initialization is only performed when using an embedded in-memory database. To always initialize a SQL database, irrespective of its type, set spring.sql.init.mode to always. Similarly, to disable initialization, set spring.sql.init.mode to never.

## 修正内容

差分通り、`application.properties` にDBを常に初期化するよう設定

## 動作確認

1. Gitpodにワークスペースを作成
2. ブランチ切り替え
3. `mvn clean` 後にテーブルが削除されていることを確認（target配下に成果物がなく、またDBに接続できない状態）
4. `./mvnw spring-boot:run` 後に正常にテーブルの作成・データ投入されていることを確認
5. 見積もりを実施後、正常にDBに登録されていることを確認

```
gitpod /workspace/tiscon8 (master) $ git checkout fix-properties
branch 'fix-properties' set up to track 'upstream/fix-properties'.
Switched to a new branch 'fix-properties'
gitpod /workspace/tiscon8 (fix-properties) $ mvn clean
Picked up JAVA_TOOL_OPTIONS:  -Xmx3489m
[INFO] Scanning for projects...
[INFO] 
[INFO] -------------------------< com.tiscon:tiscon8 >-------------------------
[INFO] Building tiscon8 0.0.1-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/3.2.0/maven-clean-plugin-3.2.0.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-clean-plugin/3.2.0/maven-clean-plugin-3.2.0.pom (5.3 kB at 12 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/35/maven-plugins-35.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-plugins/35/maven-plugins-35.pom (9.9 kB at 202 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/35/maven-parent-35.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/35/maven-parent-35.pom (45 kB at 823 kB/s)
Downloading from central: https://repo.maven.apache.org/maven2/org/apache/apache/25/apache-25.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/apache/25/apache-25.pom (21 kB at 708 kB/s)
[INFO] 
[INFO] --- maven-clean-plugin:3.2.0:clean (default-clean) @ tiscon8 ---
Downloading from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-utils/1.1/plexus-utils-1.1.jar (169 kB at 1.5 MB/s)
[INFO] Deleting /workspace/tiscon8/target
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  2.081 s
[INFO] Finished at: 2022-10-28T06:09:01Z
[INFO] ------------------------------------------------------------------------
gitpod /workspace/tiscon8 (fix-properties) $ 
gitpod /workspace/tiscon8 (fix-properties) $ 
gitpod /workspace/tiscon8 (fix-properties) $ 
gitpod /workspace/tiscon8 (fix-properties) $ ./mvnw spring-boot:run
```