### PR TITLE
workspace-full のdocker image を 2022-10-25-06-57-58 に固定する

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,7 @@
 # Please adjust to your needs (see https://www.gitpod.io/docs/config-gitpod-file)
 # and commit this file to your remote git repository to share the goodness with others.
 
-image: gitpod/workspace-full:2022-10-26-10-05-36
+image: gitpod/workspace-full:2022-10-25-06-57-58
 tasks:
   - init: ./mvnw compile
 vscode:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,7 @@
 # Please adjust to your needs (see https://www.gitpod.io/docs/config-gitpod-file)
 # and commit this file to your remote git repository to share the goodness with others.
 
+image: gitpod/workspace-full:2022-10-26-10-05-36
 tasks:
   - init: ./mvnw compile
 vscode:


### PR DESCRIPTION
## 概要

Gitpodがデフォルトで使用するワークスペースのDockerイメージを固定する。  
タグは `2022-10-25-06-57-58` とする。
https://hub.docker.com/layers/gitpod/workspace-full/2022-10-25-06-57-58/images/sha256-796b1528289518c2ba0ab6846efd664aa1128d1b3b8dbf70ea0d5bf51aa0af3c?context=explore

## 経緯

2022/11/04 午前にワークスペースを新規作成したところ、以下エラーが発生。

```
Invalid runtime for JavaSE-11: The path points to a missing or inaccessible folder (/home/gitpod/.sdkman/candidates/java/11.0.16.fx-zulu/).
```

```
gitpod ~/.sdkman/candidates/java $ ls -l
total 8
drwxr-xr-x 10 gitpod gitpod 4096 Oct  9 06:23 11.0.17.fx-zulu
drwxr-xr-x 10 gitpod gitpod 4096 Jul 12 16:15 17.0.4.fx-zulu
lrwxrwxrwx  1 gitpod gitpod   15 Oct 26 08:16 current -> 11.0.17.fx-zulu
```

原因としては、DockerイメージでJavaのアップデートが入っていたため。
https://github.com/gitpod-io/workspace-images/pull/962
https://hub.docker.com/r/gitpod/workspace-full/tags

## 対応策

`gitpod/workspace-full` は頻繁にバージョンアップされているので、Dockerイメージのタグを指定し、インターンシップ期間中は固定にする。

## そのほか検討案

シンボリックリンクの `current` があるため、settings.jsonを修正するという方法もある。  
ただ、Dockerイメージの変更頻度が高く、イメージを固定する方が確実なため不採用。

```
gitpod ~/.sdkman/candidates/java $ ls -l
total 8
drwxr-xr-x 10 gitpod gitpod 4096 Oct  9 06:23 11.0.17.fx-zulu
drwxr-xr-x 10 gitpod gitpod 4096 Jul 12 16:15 17.0.4.fx-zulu
lrwxrwxrwx  1 gitpod gitpod   15 Oct 26 08:16 current -> 11.0.17.fx-zulu
```

```
"path": "/home/gitpod/.sdkman/candidates/java/current/",
```

