### PR TITLE
propertiesファイルをUTF-8で日本語を書く(native2asciiをやめる）。

### DIFF
--- a/src/main/resources/ValidationMessages.properties
+++ b/src/main/resources/ValidationMessages.properties
@@ -1,28 +1,28 @@
 # Java EE (https://github.com/hibernate/hibernate-validator/blob/master/engine/src/main/resources/org/hibernate/validator/ValidationMessages_ja.properties)
-javax.validation.constraints.AssertFalse.message     = false \u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.AssertTrue.message      = true \u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.DecimalMax.message      = {value} ${inclusive == true ? '\u4EE5\u4E0B\u306E\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044' : '\u3088\u308A\u5C0F\u3055\u306A\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044'}
-javax.validation.constraints.DecimalMin.message      = {value} ${inclusive == true ? '\u4EE5\u4E0A\u306E\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044' : '\u3088\u308A\u5927\u304D\u306A\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044'}
-javax.validation.constraints.Digits.message          = \u5024\u306F\u6B21\u306E\u7BC4\u56F2\u306B\u3057\u3066\u304F\u3060\u3055\u3044 (<\u6574\u6570 {integer} \u6841>.<\u5C0F\u6570\u70B9\u4EE5\u4E0B {fraction} \u6841>)
-javax.validation.constraints.Email.message           = \u96FB\u5B50\u30E1\u30FC\u30EB\u30A2\u30C9\u30EC\u30B9\u3068\u3057\u3066\u6B63\u3057\u3044\u5F62\u5F0F\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.Future.message          = \u672A\u6765\u306E\u65E5\u4ED8\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.FutureOrPresent.message = \u73FE\u5728\u3082\u3057\u304F\u306F\u672A\u6765\u306E\u65E5\u4ED8\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.Max.message             = {value} \u4EE5\u4E0B\u306E\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.Min.message             = {value} \u4EE5\u4E0A\u306E\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.Negative.message        = 0 \u3088\u308A\u5C0F\u3055\u306A\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.NegativeOrZero.message  = 0 \u4EE5\u4E0B\u306E\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.NotBlank.message        = \u7A7A\u767D\u306F\u8A31\u53EF\u3055\u308C\u3066\u3044\u307E\u305B\u3093
-javax.validation.constraints.NotEmpty.message        = \u7A7A\u8981\u7D20\u306F\u8A31\u53EF\u3055\u308C\u3066\u3044\u307E\u305B\u3093
-javax.validation.constraints.NotNull.message         = null \u306F\u8A31\u53EF\u3055\u308C\u3066\u3044\u307E\u305B\u3093
-javax.validation.constraints.Null.message            = null \u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.Past.message            = \u904E\u53BB\u306E\u65E5\u4ED8\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.PastOrPresent.message   = \u73FE\u5728\u3082\u3057\u304F\u306F\u904E\u53BB\u306E\u65E5\u4ED8\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.Pattern.message         = \u6B63\u898F\u8868\u73FE "{regexp}" \u306B\u30DE\u30C3\u30C1\u3055\u305B\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.Positive.message        = 0 \u3088\u308A\u5927\u304D\u306A\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.PositiveOrZero.message  = 0 \u4EE5\u4E0A\u306E\u5024\u306B\u3057\u3066\u304F\u3060\u3055\u3044
-javax.validation.constraints.Size.message            = {min} \u304B\u3089 {max} \u306E\u9593\u306E\u30B5\u30A4\u30BA\u306B\u3057\u3066\u304F\u3060\u3055\u3044
+javax.validation.constraints.AssertFalse.message     = false にしてください
+javax.validation.constraints.AssertTrue.message      = true にしてください
+javax.validation.constraints.DecimalMax.message      = {value} ${inclusive == true ? '以下の値にしてください' : 'より小さな値にしてください'}
+javax.validation.constraints.DecimalMin.message      = {value} ${inclusive == true ? '以上の値にしてください' : 'より大きな値にしてください'}
+javax.validation.constraints.Digits.message          = 値は次の範囲にしてください (<整数 {integer} 桁>.<小数点以下 {fraction} 桁>)
+javax.validation.constraints.Email.message           = 電子メールアドレスとして正しい形式にしてください
+javax.validation.constraints.Future.message          = 未来の日付にしてください
+javax.validation.constraints.FutureOrPresent.message = 現在もしくは未来の日付にしてください
+javax.validation.constraints.Max.message             = {value} 以下の値にしてください
+javax.validation.constraints.Min.message             = {value} 以上の値にしてください
+javax.validation.constraints.Negative.message        = 0 より小さな値にしてください
+javax.validation.constraints.NegativeOrZero.message  = 0 以下の値にしてください
+javax.validation.constraints.NotBlank.message        = 空白は許可されていません
+javax.validation.constraints.NotEmpty.message        = 空要素は許可されていません
+javax.validation.constraints.NotNull.message         = null は許可されていません
+javax.validation.constraints.Null.message            = null にしてください
+javax.validation.constraints.Past.message            = 過去の日付にしてください
+javax.validation.constraints.PastOrPresent.message   = 現在もしくは過去の日付にしてください
+javax.validation.constraints.Pattern.message         = 正規表現 "{regexp}" にマッチさせてください
+javax.validation.constraints.Positive.message        = 0 より大きな値にしてください
+javax.validation.constraints.PositiveOrZero.message  = 0 以上の値にしてください
+javax.validation.constraints.Size.message            = {min} から {max} の間のサイズにしてください
 
 # common
-intern.Numeric.message=\u534A\u89D2\u6570\u5B57\u3067\u5165\u529B\u3057\u3066\u304F\u3060\u3055\u3044\u3002
+intern.Numeric.message=半角数字で入力してください。
 
 


### PR DESCRIPTION
Java9からpropertiesファイルはUTF-8で書けるようになったため。

https://www.oracle.com/java/technologies/javase/9-enhancements.html#JDK-8027607