### PR TITLE
引数の型は表示しない＆git pullでrebaseしないように設定を追加する

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,9 @@
 
 image: gitpod/workspace-full:2022-10-25-06-57-58
 tasks:
-  - init: ./mvnw compile
+  - init:
+      ./mvnw compile
+      git config pull.rebase false
 vscode:
   extensions:
     - vscjava.vscode-java-pack

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@
 
 image: gitpod/workspace-full:2022-10-25-06-57-58
 tasks:
-  - init:
+  - init: |
       ./mvnw compile
       git config pull.rebase false
 vscode:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
       "path": "/home/gitpod/.sdkman/candidates/java/11.0.16.fx-zulu/",
       "default":  true
     }
-  ]
+  ],
+  "editor.inlayHints.enabled": "off"
 
 }


### PR DESCRIPTION
## 対応内容
チーム開発準備作業に含まれる手順を事前に設定しておくように変更する。

- `git config pull.rebase false` の手順
   - Git 2.27.0以降で必要なpullの設定。
   - https://blog.agile.esm.co.jp/entry/git-warns-pulling-without-specifying-how-to-reconcile-divergent-branches
- 引数の型をエディタ上に表示する、InlayHintsの無効化


## 動作確認

以下リポジトリをもとに新規ワークスペースを作り、動作確認を実施。
https://github.com/takkii1010/tiscon8

## 補足
12/23(金)が事前準備案内日なので、12/22中にマージしたい